### PR TITLE
Upgrade insecure page requests

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,4 +1,10 @@
 window.onload = function () {
+    /* HTTPS upgrade */
+    /* Prevent possible microphone API permissions issues */
+    if (location.protocol !== "https:") {
+        location.protocol = "https:";
+    }
+
     /* TOEFL section */
     /* Remove blocking box */
     document.querySelectorAll('.shield-box').forEach(s => s.remove());


### PR DESCRIPTION
Since Chrome 68 & Firefox 68, http sites are marked as not secured, and microphone API access from pages is blocked by default.

As a result, KMF will show following obscure message for HTTP visitors:

![messageImage_1634204397276](https://user-images.githubusercontent.com/14349/137359757-576efb36-d093-438b-a3c6-04cbde0fe899.jpeg)

So in this PR, I added a quick check for URL scheme and upgrade any non HTTPS page requests.

Though it's not in the scope of this extension's purpose (i.e. unblock access), I believe this could help many less tech savvy people.